### PR TITLE
Remove .gitignore because program relies on fresh cloned clr-bundles dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-cloned_repo/
-bundles.html


### PR DESCRIPTION
NOTE:  ``cloned_repo``, must be addressed in .sh programmatically, as called from Make file:
* ``rm cloned_repo/clr-bundles`` each time after every build
